### PR TITLE
Extend filter on account analytic lines

### DIFF
--- a/report/report_timesheets.py
+++ b/report/report_timesheets.py
@@ -38,22 +38,71 @@ class ReportTimesheet(models.AbstractModel):
             "Generating TimeSheet"
         )
 
+
         if docs.from_date and docs.to_date:
             rec = self.env['account.analytic.line'].search([('user_id', '=', docs.employee[0].id),
                                                             ('date', '>=', docs.from_date),
                                                             ('date', '<=', docs.to_date)])
+
+            rec2filter = self.env['account.analytic.line'].search([('user_id', '=', docs.employee[0].id),
+                                                            ('date', '>=', docs.from_date),
+                                                            ('date', '<=', docs.to_date),
+                                                            ('project_id', '=', False),
+                                                            ('employee_id', '=', False),
+                                                            ('product_id', '!=', False),
+                                                            ('general_account_id', '!=', False),
+                                                            ('move_id', '!=', False),
+                                                            ('timesheet_invoice_type', '=', False),
+                                                            ])
+
         elif docs.from_date:
             rec = self.env['account.analytic.line'].search([('user_id', '=', docs.employee[0].id),
                                                             ('date', '>=', docs.from_date)])
+
+            rec2filter = self.env['account.analytic.line'].search([('user_id', '=', docs.employee[0].id),
+                                                            ('date', '>=', docs.from_date),
+                                                            ('project_id', '=', False),
+                                                            ('employee_id', '=', False),
+                                                            ('product_id', '!=', False),
+                                                            ('general_account_id', '!=', False),
+                                                            ('move_id', '!=', False),
+                                                            ('timesheet_invoice_type', '=', False),
+                                                            ])
+
         elif docs.to_date:
             rec = self.env['account.analytic.line'].search([('user_id', '=', docs.employee[0].id),
                                                             ('date', '<=', docs.to_date)])
+
+            rec2filter = self.env['account.analytic.line'].search([('user_id', '=', docs.employee[0].id),
+                                                            ('date', '<=', docs.to_date),
+                                                            ('project_id', '=', False),
+                                                            ('employee_id', '=', False),
+                                                            ('product_id', '!=', False),
+                                                            ('general_account_id', '!=', False),
+                                                            ('move_id', '!=', False),
+                                                            ('timesheet_invoice_type', '=', False),
+                                                            ])
+
         else:
             rec = self.env['account.analytic.line'].search([('user_id', '=', docs.employee[0].id)])
+
+            rec2filter = self.env['account.analytic.line'].search([('user_id', '=', docs.employee[0].id),
+                                                            ('project_id', '=', False),
+                                                            ('employee_id', '=', False),
+                                                            ('product_id', '!=', False),
+                                                            ('general_account_id', '!=', False),
+                                                            ('move_id', '!=', False),
+                                                            ('timesheet_invoice_type', '=', False),
+                                                                   ])
+
+
+        rec2filter_ids = [r.id for r in rec2filter]
 
         records = {}
         total = 0
         for r in rec:
+            if r.id in rec2filter_ids:
+                continue
             reports = []
             hours = 0
             if r.project_id.name in records:
@@ -74,7 +123,7 @@ class ReportTimesheet(models.AbstractModel):
 
 
         def convert(record_in):
-            """We perform a group by on the task name, 
+            """We perform a group by on the task name,
             and add a subtotal line and a whiteline for every group
 
             We order on taskname, preferable on the WPnumber (to prevent WP10 is printed before WP1).


### PR DESCRIPTION
Commit comment by JNI
---

This is quite a generic table, and we find more than timesheet related records.

In this situation we deal with expense related records, and we do not want them to appear on the timesheet report (printed from the timesheet wizard 'Print timesheets').

Instead of updating the query to find the timesheet related records that we need for the report, we choose otherwise: We look for the records that we do not want to appear on the report. There are 6 attributes that we can use to uniquely identify the expense related acc.analytic lines, given the current dataset. Using one attribute would already be enough, but we rather use a combination as it is unclear if future data conforms to the patterns we currently see (and expect) in the table.

Using a combination makes the (overall) filter more strict with respect to non timesheet related records. We do not want False Negatives for the filter on timesheet related records, we rather have False Positives. That might mean that in the future, lines might show up on the report, that do not belong there, if so, we could update the filter (again).