### PR TITLE
Changed user to employee, such that for employees (in particular mana…

### DIFF
--- a/report/report_timesheets.py
+++ b/report/report_timesheets.py
@@ -159,7 +159,7 @@ class ReportTimesheet(models.AbstractModel):
         we pass the objects in the docargs dictionary"""
         docs = self.env['timesheet.wizard'].browse(self.env.context.get('active_id'))
         identification = []
-        for i in self.env['hr.employee'].search([('user_id', '=', docs.employee[0].id)]):
+        for i in self.env['hr.employee'].search([('id', '=', docs.employee[0].id)]):
             if i:
                 identification.append({'id': i.id, 'name': i.name})
         timesheets = self.get_timesheets(docs)

--- a/report/report_timesheets.py
+++ b/report/report_timesheets.py
@@ -44,70 +44,20 @@ class ReportTimesheet(models.AbstractModel):
                                                             ('date', '>=', docs.from_date),
                                                             ('date', '<=', docs.to_date)])
 
-            rec2filter = self.env['account.analytic.line'].search([('user_id', '=', docs.employee[0].id),
-                                                            ('date', '>=', docs.from_date),
-                                                            ('date', '<=', docs.to_date),
-                                                            ('project_id', '=', False),
-                                                            ('employee_id', '=', False),
-                                                            ('product_id', '!=', False),
-                                                            ('general_account_id', '!=', False),
-                                                            ('move_id', '!=', False),
-                                                            ('timesheet_invoice_type', '=', False),
-                                                            ])
-
         elif docs.from_date:
             rec = self.env['account.analytic.line'].search([('employee_id', '=', docs.employee[0].id),
                                                             ('date', '>=', docs.from_date)])
-
-            rec2filter = self.env['account.analytic.line'].search([('user_id', '=', docs.employee[0].id),
-                                                            ('date', '>=', docs.from_date),
-                                                            ('project_id', '=', False),
-                                                            ('employee_id', '=', False),
-                                                            ('product_id', '!=', False),
-                                                            ('general_account_id', '!=', False),
-                                                            ('move_id', '!=', False),
-                                                            ('timesheet_invoice_type', '=', False),
-                                                            ])
 
         elif docs.to_date:
             rec = self.env['account.analytic.line'].search([('employee_id', '=', docs.employee[0].id),
                                                             ('date', '<=', docs.to_date)])
 
-            rec2filter = self.env['account.analytic.line'].search([('user_id', '=', docs.employee[0].id),
-                                                            ('date', '<=', docs.to_date),
-                                                            ('project_id', '=', False),
-                                                            ('employee_id', '=', False),
-                                                            ('product_id', '!=', False),
-                                                            ('general_account_id', '!=', False),
-                                                            ('move_id', '!=', False),
-                                                            ('timesheet_invoice_type', '=', False),
-                                                            ])
-
         else:
             rec = self.env['account.analytic.line'].search([('employee_id', '=', docs.employee[0].id)])
-
-
-
-
-
-
-            rec2filter = self.env['account.analytic.line'].search([('user_id', '=', docs.employee[0].id),
-                                                            ('project_id', '=', False),
-                                                            ('employee_id', '=', False),
-                                                            ('product_id', '!=', False),
-                                                            ('general_account_id', '!=', False),
-                                                            ('move_id', '!=', False),
-                                                            ('timesheet_invoice_type', '=', False),
-                                                                   ])
-
-
-        rec2filter_ids = [r.id for r in rec2filter]
 
         records = {}
         total = 0
         for r in rec:
-            if r.id in rec2filter_ids:
-                continue
             reports = []
             hours = 0
             if r.project_id.name in records:

--- a/report/report_timesheets.py
+++ b/report/report_timesheets.py
@@ -38,18 +38,26 @@ class ReportTimesheet(models.AbstractModel):
             "Generating TimeSheet"
         )
 
+
+
+
         if docs.from_date and docs.to_date:
-            rec = self.env['account.analytic.line'].search([('user_id', '=', docs.employee[0].id),
+            rec = self.env['account.analytic.line'].search([('employee_id', '=', docs.employee[0].id),
                                                             ('date', '>=', docs.from_date),
                                                             ('date', '<=', docs.to_date)])
         elif docs.from_date:
-            rec = self.env['account.analytic.line'].search([('user_id', '=', docs.employee[0].id),
+            rec = self.env['account.analytic.line'].search([('employee_id', '=', docs.employee[0].id),
                                                             ('date', '>=', docs.from_date)])
         elif docs.to_date:
-            rec = self.env['account.analytic.line'].search([('user_id', '=', docs.employee[0].id),
+            rec = self.env['account.analytic.line'].search([('employee_id', '=', docs.employee[0].id),
                                                             ('date', '<=', docs.to_date)])
         else:
-            rec = self.env['account.analytic.line'].search([('user_id', '=', docs.employee[0].id)])
+            rec = self.env['account.analytic.line'].search([('employee_id', '=', docs.employee[0].id)])
+
+
+
+
+
 
         records = {}
         total = 0
@@ -74,7 +82,7 @@ class ReportTimesheet(models.AbstractModel):
 
 
         def convert(record_in):
-            """We perform a group by on the task name, 
+            """We perform a group by on the task name,
             and add a subtotal line and a whiteline for every group
 
             We order on taskname, preferable on the WPnumber (to prevent WP10 is printed before WP1).

--- a/wizard/timesheet_employee.py
+++ b/wizard/timesheet_employee.py
@@ -25,7 +25,7 @@ from odoo import models, fields
 class EmployeeTimesheet(models.TransientModel):
     _name = 'timesheet.wizard'
 
-    employee = fields.Many2one('res.users', string="Employee", required=True)
+    employee = fields.Many2one('hr.employee', string="Employee", required=True)
     from_date = fields.Date(string="Starting Date")
     to_date = fields.Date(string="Ending Date")
 


### PR DESCRIPTION
…gers) who write hours in timesheets in multiple organisations (and for which two employees are definied within Odoo) it is clear from the dropdown menu in the print timesheet wizard, from which organisation the hours are chosen. If we want to see the hours of another organisation we need to change company first using the respective button.

Note: The record rules are important here! See settings of Odoo (activate developer mode first): there is a record rule on Employee.